### PR TITLE
Issue 7: Clarification/Reverse-Question Bot (Feedback to Slack)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { GeminiEngine } from "./gemini.js";
 import { GitHubClient } from "./github.js";
+import { GeminiAnalysisResult } from "./types.js";
 import { App, SlackEventMiddlewareArgs, SlackMessageMiddlewareArgs } from "@slack/bolt";
 import * as dotenv from "dotenv";
 import { fileURLToPath } from 'url';
@@ -18,6 +19,24 @@ export const app = new App({
   socketMode: true,
   appToken: process.env.SLACK_APP_TOKEN || "xapp-dummy",
 });
+
+/**
+ * Formats the Slack reply message based on Gemini analysis.
+ */
+export function formatSlackReply(result: GeminiAnalysisResult, issueUrl: string): string {
+  let message = `GitHub Issue created: ${issueUrl}\nCategory: ${result.category}`;
+
+  const needsClarification = result.is_ambiguous || result.category === "[Clarify]" || result.category === "[Dependency]";
+
+  if (needsClarification && result.missing_info && result.missing_info.length > 0) {
+    message += `\n\n*Missing Information / Questions:*`;
+    result.missing_info.forEach(info => {
+      message += `\n- ${info}`;
+    });
+  }
+
+  return message;
+}
 
 // app_mention handler
 app.event("app_mention", async ({ event, client, logger }: SlackEventMiddlewareArgs<'app_mention'>) => {
@@ -42,7 +61,7 @@ app.event("app_mention", async ({ event, client, logger }: SlackEventMiddlewareA
     await client.chat.postMessage({
       channel,
       thread_ts: ts,
-      text: `GitHub Issue created: ${issue.html_url}\nCategory: ${result.category}`,
+      text: formatSlackReply(result, issue.html_url),
     });
   } catch (error) {
     logger.error(error);
@@ -77,7 +96,7 @@ app.message(async ({ message, client, logger }: SlackMessageMiddlewareArgs) => {
     await client.chat.postMessage({
       channel,
       thread_ts: ts,
-      text: `GitHub Issue created: ${issue.html_url}\nCategory: ${result.category}`,
+      text: formatSlackReply(result, issue.html_url),
     });
   } catch (error) {
     logger.error(error);

--- a/tests/test_slack_feedback.ts
+++ b/tests/test_slack_feedback.ts
@@ -1,0 +1,100 @@
+import { formatSlackReply } from '../src/index.js';
+import { GeminiAnalysisResult } from '../src/types.js';
+
+const mockIssueUrl = 'https://github.com/owner/repo/issues/1';
+
+const testCases = [
+  {
+    name: 'Clear Feature Request',
+    result: {
+      category: '[Feature]',
+      title: 'Add login',
+      description: 'Add Google login',
+      acceptance_criteria: 'Given...',
+      is_ambiguous: false,
+      missing_info: []
+    } as GeminiAnalysisResult,
+    expectedContains: [
+      'GitHub Issue created: https://github.com/owner/repo/issues/1',
+      'Category: [Feature]'
+    ],
+    expectedNotContains: ['Missing Information']
+  },
+  {
+    name: 'Ambiguous Clarify Request',
+    result: {
+      category: '[Clarify]',
+      title: 'Vague request',
+      description: 'Something vague',
+      acceptance_criteria: '',
+      is_ambiguous: true,
+      missing_info: ['What is the goal?', 'Who is the user?']
+    } as GeminiAnalysisResult,
+    expectedContains: [
+      'GitHub Issue created: https://github.com/owner/repo/issues/1',
+      'Category: [Clarify]',
+      '*Missing Information / Questions:*',
+      '- What is the goal?',
+      '- Who is the user?'
+    ]
+  },
+  {
+    name: 'Dependency Request',
+    result: {
+      category: '[Dependency]',
+      title: 'Need API Key',
+      description: 'Need Stripe API key',
+      acceptance_criteria: '',
+      is_ambiguous: false,
+      missing_info: ['Please provide the production API key']
+    } as GeminiAnalysisResult,
+    expectedContains: [
+      'GitHub Issue created: https://github.com/owner/repo/issues/1',
+      'Category: [Dependency]',
+      '*Missing Information / Questions:*',
+      '- Please provide the production API key'
+    ]
+  }
+];
+
+function runTests() {
+  console.log('Starting formatSlackReply tests...');
+  let anyFailed = false;
+  testCases.forEach(tc => {
+    console.log(`Running test: ${tc.name}`);
+    const actual = formatSlackReply(tc.result, mockIssueUrl);
+    let failed = false;
+
+    tc.expectedContains.forEach(expected => {
+      if (!actual.includes(expected)) {
+        console.error(`  ❌ Failed: Expected to contain "${expected}"`);
+        failed = true;
+      }
+    });
+
+    if (tc.expectedNotContains) {
+      tc.expectedNotContains.forEach(notExpected => {
+        if (actual.includes(notExpected)) {
+          console.error(`  ❌ Failed: Expected NOT to contain "${notExpected}"`);
+          failed = true;
+        }
+      });
+    }
+
+    if (!failed) {
+      console.log(`  ✅ Passed`);
+    } else {
+      console.error(`     Actual: "${actual}"`);
+      anyFailed = true;
+    }
+  });
+
+  if (anyFailed) {
+    process.exit(1);
+  } else {
+    console.log('\nAll formatSlackReply tests passed!');
+    process.exit(0);
+  }
+}
+
+runTests();


### PR DESCRIPTION
This change addresses Issue 7 by providing better feedback to users on Slack. When a request is deemed ambiguous or is categorized as needing clarification or dependency data, the bot now includes the specific questions generated by Gemini in its Slack reply, alongside the link to the created GitHub issue.

Fixes #8

---
*PR created automatically by Jules for task [14031357007508164023](https://jules.google.com/task/14031357007508164023) started by @studyhelperproject*