### PR TITLE
Increase Cloud Run deployment memory to 1Gi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           gcloud run deploy $SERVICE_NAME \
             --project $PROJECT_ID \
+            --memory=1Gi \
             --source . \
             --region $REGION \
             --platform managed \


### PR DESCRIPTION
The deployment to Cloud Run was failing due to memory constraints. This change increases the allocated memory for the service to 1Gi in the `.github/workflows/deploy.yml` file, ensuring stable deployments and runtime performance. Verified the change by inspecting the workflow file and running existing tests to ensure no regressions.

Fixes #37

---
*PR created automatically by Jules for task [16166791169633800024](https://jules.google.com/task/16166791169633800024) started by @studyhelperproject*