### PR TITLE
Fix build error by removing docs from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ data
 .env
 .git
 tests
-docs
 npm-debug.log
 .gitignore
 .dockerignore


### PR DESCRIPTION
The Docker build was failing because the `docs` directory was excluded via `.dockerignore`, but the `Dockerfile` attempted to `COPY` it. I removed `docs` from `.dockerignore` to ensure it is included in the build context. I also verified the change by running the existing test suite, which passed successfully.

Fixes #39

---
*PR created automatically by Jules for task [1870753873107945713](https://jules.google.com/task/1870753873107945713) started by @studyhelperproject*