### PR TITLE
Fix Cloud Run deployment error by ensuring consistent build output structure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,3 @@ npm-debug.log
 .dockerignore
 README.md
 AGENTS.md
-package-lock.json

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "rootDir": ".",
     "outDir": "./dist"
   },
   "include": ["src/**/*", "tests/**/*"]


### PR DESCRIPTION
The Cloud Run deployment failed because it couldn't find the entry point module at `/app/dist/src/index.js`. This happened because `tsc` was flattening the directory structure into `dist/` when the `tests/` directory was excluded by `.dockerignore`.

I fixed this by:
1. Setting `"rootDir": "."` in `tsconfig.json` to guarantee that `src/` is always preserved in the output path.
2. Removing `package-lock.json` from `.dockerignore` to allow the build process to use the exact dependency versions specified in the lock file, ensuring environment consistency.

Verified the fix by running the build with and without the `tests` directory and confirming the presence of `dist/src/index.js` in both cases. Also ran the full test suite to ensure no regressions.

Fixes #41

---
*PR created automatically by Jules for task [6753255155984405749](https://jules.google.com/task/6753255155984405749) started by @studyhelperproject*