### PR TITLE
Resolve Slack URL Verification Challenge and Improve Startup Resilience

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,6 +67,7 @@ gcloud run deploy $SERVICE_NAME \
 3.  **Event Subscriptions**:
     - `Enable Events` をオンにします。
     - `Request URL` に `https://<YOUR_CLOUD_RUN_URL>/slack/events` を入力し、`Verified` になることを確認します。
+  - **URL Verification の補足**: 本システムは、ルートパス (`/`) でも Slack の `url_verification` チャレンジに応答するように設計されています。もし `/slack/events` での検証がうまくいかない場合は、一時的に `https://<YOUR_CLOUD_RUN_URL>/` を Request URL として設定して検証を通し、その後正しいパスに戻すことができます。
 4.  **Interactivity & Shortcuts** (オプション):
     - インタラクティブ機能を使用する場合は、Request URL に `https://<YOUR_CLOUD_RUN_URL>/slack/events` を設定します。
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,47 @@ const socketMode = process.env.SLACK_SOCKET_MODE === "true";
 const appOptions: AppOptions = {
   token: process.env.SLACK_BOT_TOKEN || "xoxb-dummy",
   signingSecret: process.env.SLACK_SIGNING_SECRET || "dummy",
+  customRoutes: [
+    {
+      path: "/health",
+      method: ["GET"],
+      handler: (req, res) => {
+        res.writeHead(200);
+        res.end("OK");
+      },
+    },
+    {
+      path: "/",
+      method: ["POST"],
+      handler: (req, res) => {
+        let body = "";
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          try {
+            const data = JSON.parse(body);
+            if (data.type === "url_verification") {
+              console.log("Handling Slack url_verification challenge at root path");
+              res.writeHead(200, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ challenge: data.challenge }));
+              return;
+            }
+            // If it's not a challenge, it might be an actual Slack event.
+            // When using HTTP Mode, Bolt expects events at /slack/events by default.
+            // We log this to help users troubleshoot misconfigured Request URLs.
+            console.warn("Received POST request at root path that is not a url_verification challenge.");
+            console.warn("If this is a Slack event, please check your App settings and ensure the Request URL is set to <YOUR_URL>/slack/events");
+            res.writeHead(404);
+            res.end("Not Found. Slack events should be sent to /slack/events");
+          } catch (e) {
+            res.writeHead(400);
+            res.end("Bad Request");
+          }
+        });
+      },
+    },
+  ],
 };
 
 if (socketMode) {
@@ -241,10 +282,13 @@ export async function main() {
     "GEMINI_API_KEY",
   ];
 
-  const missingSlackVars = slackEnvVars.filter((v) => !process.env[v]);
+  const missingSlackVars = slackEnvVars.filter((v) => {
+    const val = process.env[v];
+    return !val || val === "dummy" || val === "xoxb-dummy" || val === "xapp-dummy";
+  });
   if (missingSlackVars.length > 0) {
-    console.error(`Error: Missing required Slack environment variables: ${missingSlackVars.join(", ")}`);
-    process.exit(1);
+    console.warn(`Warning: Missing or dummy Slack environment variables: ${missingSlackVars.join(", ")}`);
+    console.warn("The app will start but Slack features may not work correctly.");
   }
 
   const missingOtherVars = otherEnvVars.filter((v) => !process.env[v] || process.env[v] === "dummy");

--- a/tests/test_slack_challenge.ts
+++ b/tests/test_slack_challenge.ts
@@ -1,0 +1,107 @@
+import { app } from '../src/index.js';
+import http from 'http';
+
+async function testChallenge() {
+  const port = 3001;
+  await app.start(port);
+  console.log(`Test app started on port ${port}`);
+
+  const challenge = "test_challenge_123";
+  const postData = JSON.stringify({
+    type: "url_verification",
+    challenge: challenge
+  });
+
+  const options = {
+    hostname: 'localhost',
+    port: port,
+    path: '/',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': postData.length
+    }
+  };
+
+  const req = http.request(options, (res) => {
+    let body = '';
+    res.on('data', (chunk) => body += chunk);
+    res.on('end', async () => {
+      console.log('Response status:', res.statusCode);
+      console.log('Response body:', body);
+
+      const data = JSON.parse(body);
+      if (res.statusCode === 200 && data.challenge === challenge) {
+        console.log('✅ Challenge test passed!');
+      } else {
+        console.error('❌ Challenge test failed!');
+        process.exit(1);
+      }
+
+      // Test non-challenge POST to root
+      const nonChallengePostData = JSON.stringify({ type: "some_other_event" });
+      const nonChallengeReq = http.request({
+        hostname: 'localhost',
+        port: port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': nonChallengePostData.length
+        }
+      }, (nonChallengeRes) => {
+        let ncBody = '';
+        nonChallengeRes.on('data', (chunk) => ncBody += chunk);
+        nonChallengeRes.on('end', () => {
+          console.log('Non-challenge POST status:', nonChallengeRes.statusCode);
+          console.log('Non-challenge POST body:', ncBody);
+          if (nonChallengeRes.statusCode === 404 && ncBody.includes('Slack events should be sent to /slack/events')) {
+            console.log('✅ Non-challenge POST test passed!');
+          } else {
+            console.error('❌ Non-challenge POST test failed!');
+            process.exit(1);
+          }
+        });
+      });
+      nonChallengeReq.write(nonChallengePostData);
+      nonChallengeReq.end();
+
+      // Test health check
+      const healthReq = http.request({
+        hostname: 'localhost',
+        port: port,
+        path: '/health',
+        method: 'GET'
+      }, (healthRes) => {
+        let healthBody = '';
+        healthRes.on('data', (chunk) => healthBody += chunk);
+        healthRes.on('end', async () => {
+          console.log('Health check status:', healthRes.statusCode);
+          console.log('Health check body:', healthBody);
+          if (healthRes.statusCode === 200 && healthBody === 'OK') {
+            console.log('✅ Health check test passed!');
+            await app.stop();
+            process.exit(0);
+          } else {
+            console.error('❌ Health check test failed!');
+            process.exit(1);
+          }
+        });
+      });
+      healthReq.end();
+    });
+  });
+
+  req.on('error', (e) => {
+    console.error(`Problem with request: ${e.message}`);
+    process.exit(1);
+  });
+
+  req.write(postData);
+  req.end();
+}
+
+testChallenge().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
This PR addresses the issue where the Slack URL verification challenge fails during initial setup. 

Key changes:
1.  **URL Verification Fallback**: Added a manual POST handler at the root path (`/`) specifically for Slack's `url_verification` challenge. This helps when users misconfigure the Slack Request URL to the root domain instead of `/slack/events`, or when they need to pass verification before full secrets are configured.
2.  **Graceful Startup**: Modified the application's startup logic in `src/index.ts` to log warnings and continue running even if required environment variables (like `SLACK_BOT_TOKEN`) are missing or set to placeholder values. This "break the chicken-and-egg" approach allows the server to stay alive to respond to the initial challenge.
3.  **Health Check**: Added a `/health` endpoint (`GET /health`) which returns "OK", useful for Cloud Run health checks.
4.  **Documentation**: Updated `docs/deployment.md` to provide guidance on how to use these new features to pass Slack verification.
5.  **Testing**: Included a new test suite `tests/test_slack_challenge.ts` that mocks challenge requests and verifies the application's response.

All existing tests pass, and the new functionality has been verified.

Fixes #45

---
*PR created automatically by Jules for task [6462026535411142851](https://jules.google.com/task/6462026535411142851) started by @studyhelperproject*