### PR TITLE
Unify Slack endpoints to root path

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,7 +58,7 @@ gcloud run deploy $SERVICE_NAME \
 
 ### 注意点
 - **HTTP Mode**: Cloud Run は通常 HTTP Mode で動作させるため、`SLACK_SOCKET_MODE=false` に設定します。
-- **Slack 設定の変更**: HTTP Mode で動かす場合、Slack App 設定の `Event Subscriptions` で、Cloud Run の URL（例: `https://.../slack/events`）を Request URL として設定する必要があります。
+- **Slack 設定の変更**: HTTP Mode で動かす場合、Slack App 設定の `Event Subscriptions` で、Cloud Run の URL（例: `https://.../`）を Request URL として設定する必要があります。
 
 ## 5. Slack App の再設定 (HTTP Mode の場合)
 
@@ -66,10 +66,9 @@ gcloud run deploy $SERVICE_NAME \
 2.  [Slack App コンソール](https://api.slack.com/apps) に移動します。
 3.  **Event Subscriptions**:
     - `Enable Events` をオンにします。
-    - `Request URL` に `https://<YOUR_CLOUD_RUN_URL>/slack/events` を入力し、`Verified` になることを確認します。
-  - **URL Verification の補足**: 本システムは、ルートパス (`/`) でも Slack の `url_verification` チャレンジに応答するように設計されています。もし `/slack/events` での検証がうまくいかない場合は、一時的に `https://<YOUR_CLOUD_RUN_URL>/` を Request URL として設定して検証を通し、その後正しいパスに戻すことができます。
+    - `Request URL` に `https://<YOUR_CLOUD_RUN_URL>/` を入力し、`Verified` になることを確認します。
 4.  **Interactivity & Shortcuts** (オプション):
-    - インタラクティブ機能を使用する場合は、Request URL に `https://<YOUR_CLOUD_RUN_URL>/slack/events` を設定します。
+    - インタラクティブ機能を使用する場合は、Request URL に `https://<YOUR_CLOUD_RUN_URL>/` を設定します。
 
 ## 6. ローカル開発と検証
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const socketMode = process.env.SLACK_SOCKET_MODE === "true";
 const appOptions: AppOptions = {
   token: getEnv("SLACK_BOT_TOKEN", "xoxb-dummy"),
   signingSecret: getEnv("SLACK_SIGNING_SECRET", "dummy"),
-  endpoints: ["/slack/events"],
+  endpoints: ["/"],
   customRoutes: [
     {
       path: "/health",
@@ -37,34 +37,10 @@ const appOptions: AppOptions = {
     },
     {
       path: "/",
-      method: ["GET", "POST"],
+      method: ["GET"],
       handler: (req, res) => {
-        if (req.method === "POST") {
-          let body = "";
-          req.on("data", (chunk) => {
-            body += chunk;
-          });
-          req.on("end", () => {
-            try {
-              const data = JSON.parse(body);
-              if (data.type === "url_verification") {
-                res.writeHead(200, { "Content-Type": "application/json" });
-                res.end(JSON.stringify({ challenge: data.challenge }));
-                return;
-              }
-              console.warn("Received POST request at root path that is not a url_verification challenge.");
-              console.warn("If this is a Slack event, please check your App settings and ensure the Request URL is set to <YOUR_URL>/slack/events");
-              res.writeHead(404);
-              res.end("Slack events should be sent to /slack/events");
-            } catch (e) {
-              res.writeHead(400);
-              res.end("Invalid JSON");
-            }
-          });
-          return;
-        }
         res.writeHead(200);
-        res.end("SysDevAutomation service is running. Slack events are accepted at /slack/events");
+        res.end("SysDevAutomation service is running. Slack events are accepted at /");
       },
     },
   ],

--- a/tests/test_slack_challenge.ts
+++ b/tests/test_slack_challenge.ts
@@ -1,5 +1,6 @@
 import { app } from '../src/index.js';
 import http from 'http';
+import crypto from 'crypto';
 
 async function testChallenge() {
   const port = 3001;
@@ -12,6 +13,14 @@ async function testChallenge() {
     challenge: challenge
   });
 
+  const signingSecret = 'dummy';
+  const timestamp = Math.floor(Date.now() / 1000);
+  const sigBaseString = `v0:${timestamp}:${postData}`;
+  const signature = 'v0=' + crypto
+    .createHmac('sha256', signingSecret)
+    .update(sigBaseString)
+    .digest('hex');
+
   const options = {
     hostname: 'localhost',
     port: port,
@@ -19,7 +28,9 @@ async function testChallenge() {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Content-Length': postData.length
+      'Content-Length': Buffer.byteLength(postData),
+      'X-Slack-Signature': signature,
+      'X-Slack-Request-Timestamp': timestamp.toString()
     }
   };
 
@@ -30,41 +41,47 @@ async function testChallenge() {
       console.log('Response status:', res.statusCode);
       console.log('Response body:', body);
 
-      const data = JSON.parse(body);
-      if (res.statusCode === 200 && data.challenge === challenge) {
+      // Bolt handles url_verification automatically.
+      // It returns 200 and the challenge if correctly formatted, even without a valid signature.
+      let data;
+      try {
+        data = JSON.parse(body);
+      } catch (e) {
+        console.error('Failed to parse response body as JSON:', body);
+      }
+
+      if (res.statusCode === 200 && data && data.challenge === challenge) {
         console.log('✅ Challenge test passed!');
       } else {
+        // If it fails with 401, it might be because Bolt now enforces signatures even for challenges
+        // in some versions or configurations when endpoints are unified.
+        // However, usually url_verification is an exception.
+        // In this case, we see it failed with 401 in the previous run.
         console.error('❌ Challenge test failed!');
         process.exit(1);
       }
 
-      // Test non-challenge POST to root
-      const nonChallengePostData = JSON.stringify({ type: "some_other_event" });
-      const nonChallengeReq = http.request({
+      // Test GET to root
+      const getReq = http.request({
         hostname: 'localhost',
         port: port,
         path: '/',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': nonChallengePostData.length
-        }
-      }, (nonChallengeRes) => {
-        let ncBody = '';
-        nonChallengeRes.on('data', (chunk) => ncBody += chunk);
-        nonChallengeRes.on('end', () => {
-          console.log('Non-challenge POST status:', nonChallengeRes.statusCode);
-          console.log('Non-challenge POST body:', ncBody);
-          if (nonChallengeRes.statusCode === 404 && ncBody.includes('Slack events should be sent to /slack/events')) {
-            console.log('✅ Non-challenge POST test passed!');
+        method: 'GET'
+      }, (getRes) => {
+        let getBody = '';
+        getRes.on('data', (chunk) => getBody += chunk);
+        getRes.on('end', () => {
+          console.log('GET / status:', getRes.statusCode);
+          console.log('GET / body:', getBody);
+          if (getRes.statusCode === 200 && getBody.includes('Slack events are accepted at /')) {
+            console.log('✅ GET / test passed!');
           } else {
-            console.error('❌ Non-challenge POST test failed!');
+            console.error('❌ GET / test failed!');
             process.exit(1);
           }
         });
       });
-      nonChallengeReq.write(nonChallengePostData);
-      nonChallengeReq.end();
+      getReq.end();
 
       // Test health check
       const healthReq = http.request({


### PR DESCRIPTION
Unified Slack event and challenge handling at the root path (`/`) using Bolt's built-in endpoint management. Previously, challenges were handled manually at `/` while events were handled at `/slack/events`. This unification simplifies Slack App configuration and ensures consistent signature verification for all incoming requests. Documentation and tests have been updated accordingly.

Fixes #51

---
*PR created automatically by Jules for task [1783315084570633763](https://jules.google.com/task/1783315084570633763) started by @studyhelperproject*