### PR TITLE
Implement "assign-to-jules" label creation and assignment

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -43,6 +43,31 @@ export class GitHubClient {
     }
   }
 
+  private async ensureLabelExists(name: string, color: string): Promise<void> {
+    try {
+      await this.octokit.rest.issues.getLabel({
+        owner: this.owner,
+        repo: this.repo,
+        name: name,
+      });
+    } catch (error: any) {
+      if (error.status === 404) {
+        try {
+          await this.octokit.rest.issues.createLabel({
+            owner: this.owner,
+            repo: this.repo,
+            name: name,
+            color: color,
+          });
+        } catch (createError) {
+          console.error(`Failed to create label ${name}:`, createError);
+        }
+      } else {
+        console.error(`Failed to get label ${name}:`, error);
+      }
+    }
+  }
+
   async ensureLabelsExist(): Promise<void> {
     const labelsToCreate = [
       { name: "[Feature]", color: "a2eeef" },
@@ -55,31 +80,11 @@ export class GitHubClient {
       { name: "SP: 3", color: "006b75" },
       { name: "SP: 5", color: "006b75" },
       { name: "SP: 8", color: "006b75" },
+      { name: "assign-to-jules", color: "fbca04" },
     ];
 
     for (const label of labelsToCreate) {
-      try {
-        await this.octokit.rest.issues.getLabel({
-          owner: this.owner,
-          repo: this.repo,
-          name: label.name,
-        });
-      } catch (error: any) {
-        if (error.status === 404) {
-          try {
-            await this.octokit.rest.issues.createLabel({
-              owner: this.owner,
-              repo: this.repo,
-              name: label.name,
-              color: label.color,
-            });
-          } catch (createError) {
-            console.error(`Failed to create label ${label.name}:`, createError);
-          }
-        } else {
-          console.error(`Failed to get label ${label.name}:`, error);
-        }
-      }
+      await this.ensureLabelExists(label.name, label.color);
     }
   }
 
@@ -121,6 +126,11 @@ export class GitHubClient {
     if (result.type) labels.push(`Type: ${result.type}`);
     if (result.status) labels.push(`Status: ${result.status}`);
     if (result.priority) labels.push(`Priority: ${result.priority}`);
+
+    if (category === "[Feature]") {
+      await this.ensureLabelExists("assign-to-jules", "fbca04");
+      labels.push("assign-to-jules");
+    }
 
     try {
       const response = await this.octokit.rest.issues.create({

--- a/tests/test_context_management.ts
+++ b/tests/test_context_management.ts
@@ -9,6 +9,12 @@ class MockOctokit {
       create: async (params: any) => {
         return { data: { html_url: "https://github.com/mock/issue", ...params } };
       },
+      getLabel: async (params: any) => {
+        return { data: { name: params.name } };
+      },
+      createLabel: async (params: any) => {
+        return { data: { name: params.name, color: params.color } };
+      },
       listForRepo: () => {} // Dummy for paginate
     }
   };

--- a/tests/test_github_client.ts
+++ b/tests/test_github_client.ts
@@ -8,9 +8,44 @@ class MockOctokit {
     issues: {
       create: async (params: any) => {
         return { data: { html_url: "https://github.com/mock/issue", ...params } };
+      },
+      getLabel: async (params: any) => {
+        return { data: { name: params.name } };
+      },
+      createLabel: async (params: any) => {
+        return { data: { name: params.name, color: params.color } };
       }
     }
   };
+}
+
+async function testGitHubClientAssignToJules() {
+  console.log("Running testGitHubClientAssignToJules...");
+
+  const client = new GitHubClient("fake-token", "owner/repo");
+  // @ts-ignore: Access private property for testing or inject mock
+  client.octokit = new MockOctokit();
+
+  const featureResult: GeminiAnalysisResult = {
+    category: "[Feature]",
+    title: "Clear Requirement",
+    description: "Implement search feature.",
+    acceptance_criteria: "Given... When... Then...",
+    is_ambiguous: false,
+    missing_info: []
+  };
+
+  const issue = await client.createIssue(featureResult);
+
+  console.log("Created Issue Title:", issue.title);
+  console.log("Created Issue Labels:", issue.labels);
+
+  if (issue.labels.includes("assign-to-jules") && issue.labels.includes("[Feature]")) {
+    console.log("✅ Test Passed: [Feature] issue correctly assigned 'assign-to-jules' label.");
+  } else {
+    console.error("❌ Test Failed: [Feature] issue was not correctly labeled.");
+    process.exit(1);
+  }
 }
 
 async function testGitHubClientAmbiguity() {
@@ -49,7 +84,12 @@ async function testGitHubClientAmbiguity() {
   }
 }
 
-testGitHubClientAmbiguity().catch(err => {
+async function runTests() {
+  await testGitHubClientAssignToJules();
+  await testGitHubClientAmbiguity();
+}
+
+runTests().catch(err => {
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
This PR implements a feature to automatically create and assign the "assign-to-jules" label to GitHub issues when they are ready for development.

Key changes:
- Refactored label management in `src/github.ts` with a new private `ensureLabelExists` method.
- Added "assign-to-jules" to the default label set (color: #fbca04).
- Updated `createIssue` to append the "assign-to-jules" label specifically for non-ambiguous "[Feature]" issues.
- Enhanced the test suite (`tests/test_github_client.ts` and `tests/test_context_management.ts`) to verify these changes and ensure mock compatibility.

Fixes #57

---
*PR created automatically by Jules for task [12791083042579419124](https://jules.google.com/task/12791083042579419124) started by @studyhelperproject*