### PR TITLE
Implement Issue Update and Comment Actions

### DIFF
--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -15,6 +15,11 @@ export class GeminiEngine {
 
 Slackからの入力を分析し、以下のいずれかのアクションを選択し、指定のJSON形式で出力してください。
 
+■アクションの種類
+- create: 新規にIssueを作成する。
+- update: 既存のIssueの内容を更新する。特に [Clarify] ラベルの付いたIssueに対して、ユーザーから追加情報が得られた場合に使用する。
+- comment: 既存のIssueにコメントを追加する。進捗の報告や、軽微な追記に使用する。
+
 ■分類タグの定義
 - [Feature]: 実装すべき機能。仕様が明確なもの。
 - [Clarify]: 定義が不足しており、見積もり不能な項目。
@@ -27,9 +32,12 @@ Slackからの入力を分析し、以下のいずれかのアクションを選
 - 「ログイン機能を追加して」といった抽象的で範囲が広すぎる要望も、具体的な要件が特定できないため is_ambiguous: true とし、category: [Clarify] としてください。
 - [Feature] と判定するためには、その機能が「何を」「いつ」「どのように」するかが明確である必要があります（例：「Google OAuthを使用したログイン機能を追加し、ユーザー情報をDBに保存する」は [Feature]）。
 - [Feature] の場合、Acceptance Criteria（受入基準）を「Given/When/Then」形式で記述してください。
+- **重要**: 既存の [Clarify] Issueに関連する発言の場合、新規作成（create）せず、既存のIssueを更新（update）またはコメント（comment）してください。これにより情報の断片化を防ぎます。
 
 ■出力フォーマット (JSON)
 {
+  "action": "create | update | comment",
+  "issue_number": number (update/commentの場合に必須),
   "category": "[Feature] | [Clarify] | [Dependency] | [Estimate] | [Out of Scope]",
   "title": "Issueのタイトル（簡潔かつ具体的）",
   "description": "詳細な説明",
@@ -42,7 +50,8 @@ Slackからの入力を分析し、以下のいずれかのアクションを選
 }
 
 ■コンテキストの活用
-過去のIssue状況（スナップショット）が提供された場合、重複する要望がないか確認し、関連性がある場合は説明に含めてください。
+過去のIssue状況（スナップショット）が提供された場合、重複する要望がないか確認してください。
+既存のIssueを更新（update）する場合は、元の内容（description等）を活かしつつ、最新の情報を反映させた「完成版」のIssue内容を提供してください。
 Slackのスレッド履歴が提供された場合、これまでの会話の流れを把握し、すでにユーザーから提供された情報を再度質問しないようにしてください。
 `,
     });

--- a/src/github.ts
+++ b/src/github.ts
@@ -88,7 +88,7 @@ export class GitHubClient {
     }
   }
 
-  async createIssue(result: GeminiAnalysisResult, slackLink?: string): Promise<any> {
+  private async prepareIssueData(result: GeminiAnalysisResult, slackLink?: string) {
     const labelMap: Record<string, string> = {
       "[Feature]": "[Feature]",
       "[Clarify]": "[Q]",
@@ -132,17 +132,62 @@ export class GitHubClient {
       labels.push("assign-to-jules");
     }
 
+    return {
+      title: `${category} ${result.title}`,
+      body,
+      labels,
+      category,
+    };
+  }
+
+  async createIssue(result: GeminiAnalysisResult, slackLink?: string): Promise<any> {
+    const { title, body, labels } = await this.prepareIssueData(result, slackLink);
+
     try {
       const response = await this.octokit.rest.issues.create({
         owner: this.owner,
         repo: this.repo,
-        title: `${category} ${result.title}`,
+        title,
         body,
-        labels: labels,
+        labels,
       });
       return response.data;
     } catch (error) {
       console.error("Failed to create GitHub issue:", error);
+      throw error;
+    }
+  }
+
+  async updateIssue(issueNumber: number, result: GeminiAnalysisResult, slackLink?: string): Promise<any> {
+    const { title, body, labels } = await this.prepareIssueData(result, slackLink);
+
+    try {
+      const response = await this.octokit.rest.issues.update({
+        owner: this.owner,
+        repo: this.repo,
+        issue_number: issueNumber,
+        title,
+        body,
+        labels,
+      });
+      return response.data;
+    } catch (error) {
+      console.error(`Failed to update GitHub issue #${issueNumber}:`, error);
+      throw error;
+    }
+  }
+
+  async addComment(issueNumber: number, commentBody: string): Promise<any> {
+    try {
+      const response = await this.octokit.rest.issues.createComment({
+        owner: this.owner,
+        repo: this.repo,
+        issue_number: issueNumber,
+        body: commentBody,
+      });
+      return response.data;
+    } catch (error) {
+      console.error(`Failed to add comment to GitHub issue #${issueNumber}:`, error);
       throw error;
     }
   }
@@ -158,7 +203,9 @@ export class GitHubClient {
       const snapshot = issues
         .filter((issue) => !issue.pull_request)
         .map((issue) => ({
+          number: issue.number,
           title: issue.title,
+          body: issue.body,
           labels: issue.labels.map((l: any) => (typeof l === "string" ? l : l.name)),
         }));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,11 @@ export const app = new App(appOptions);
  * Formats the Slack reply message based on Gemini analysis.
  */
 export function formatSlackReply(result: GeminiAnalysisResult, issueUrl: string): string {
-  let message = `GitHub Issue created: ${issueUrl}\nCategory: ${result.category}`;
+  let actionText = "created";
+  if (result.action === "update") actionText = "updated";
+  if (result.action === "comment") actionText = "commented on";
+
+  let message = `GitHub Issue ${actionText}: ${issueUrl}\nCategory: ${result.category}`;
 
   const needsClarification = result.is_ambiguous || result.category === "[Clarify]" || result.category === "[Dependency]";
 
@@ -160,9 +164,20 @@ async function handleSlackMessage({ text, ts, thread_ts, channel, client, logger
     const result = await geminiEngine.analyzeMessage(text, context, threadHistory);
     console.log("Gemini Analysis:", JSON.stringify(result, null, 2));
 
-    // Create GitHub issue
-    const issue = await channelGitHubClient.createIssue(result, permalink);
-    console.log("GitHub Issue Created:", issue.html_url);
+    // Perform action on GitHub issue
+    let issue;
+    if (result.action === "update" && result.issue_number) {
+      issue = await channelGitHubClient.updateIssue(result.issue_number, result, permalink);
+      console.log(`GitHub Issue Updated: #${result.issue_number}`);
+    } else if (result.action === "comment" && result.issue_number) {
+      // For comments, we use description as the comment body
+      const comment = await channelGitHubClient.addComment(result.issue_number, result.description);
+      issue = { html_url: comment.html_url }; // Minimal issue-like object for formatSlackReply
+      console.log(`GitHub Comment Added to: #${result.issue_number}`);
+    } else {
+      issue = await channelGitHubClient.createIssue(result, permalink);
+      console.log("GitHub Issue Created:", issue.html_url);
+    }
 
     // Reply to Slack
     await client.chat.postMessage({

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,4 +8,6 @@ export interface GeminiAnalysisResult {
   type?: string;
   status?: string;
   priority?: string;
+  action: 'create' | 'update' | 'comment';
+  issue_number?: number;
 }

--- a/tests/test_context_management.ts
+++ b/tests/test_context_management.ts
@@ -23,17 +23,23 @@ class MockOctokit {
     if (params.state === "open") {
       return [
         {
+          number: 1,
           title: "Existing Feature",
+          body: "Existing body",
           labels: [{ name: "SP: 5" }, { name: "Type: Feature" }],
           pull_request: null
         },
         {
+          number: 2,
           title: "Clarification Needed",
+          body: "Vague body",
           labels: [{ name: "[Q]" }],
           pull_request: null
         },
         {
+          number: 3,
           title: "PR Title",
+          body: "PR body",
           labels: [],
           pull_request: {}
         }
@@ -59,14 +65,14 @@ async function testGetProjectContext() {
     process.exit(1);
   }
 
-  if (parsed[0].title === "Existing Feature" && parsed[0].labels.includes("Type: Feature")) {
+  if (parsed[0].number === 1 && parsed[0].title === "Existing Feature" && parsed[0].body === "Existing body" && parsed[0].labels.includes("Type: Feature")) {
     console.log("✅ Test Passed: Issue 1 correctly captured.");
   } else {
     console.error("❌ Test Failed: Issue 1 data incorrect.");
     process.exit(1);
   }
 
-  if (parsed[1].title === "Clarification Needed" && parsed[1].labels.includes("[Q]")) {
+  if (parsed[1].number === 2 && parsed[1].title === "Clarification Needed" && parsed[1].body === "Vague body" && parsed[1].labels.includes("[Q]")) {
     console.log("✅ Test Passed: Issue 2 correctly captured.");
   } else {
     console.error("❌ Test Failed: Issue 2 data incorrect.");
@@ -81,6 +87,7 @@ async function testCreateIssueWithMetadata() {
   client.octokit = new MockOctokit();
 
   const result: GeminiAnalysisResult = {
+    action: "create",
     category: "[Feature]",
     title: "New Feature",
     description: "Description",

--- a/tests/test_github_client.ts
+++ b/tests/test_github_client.ts
@@ -1,10 +1,14 @@
 import { GitHubClient } from "../src/github.js";
 import { GeminiAnalysisResult } from "../src/types.js";
-import { assert } from "console";
 
 // Mock Octokit
 class MockOctokit {
   rest = {
+    users: {
+      getAuthenticated: async () => {
+        return { data: { login: "owner" } };
+      }
+    },
     issues: {
       create: async (params: any) => {
         return { data: { html_url: "https://github.com/mock/issue", ...params } };
@@ -14,6 +18,12 @@ class MockOctokit {
       },
       createLabel: async (params: any) => {
         return { data: { name: params.name, color: params.color } };
+      },
+      update: async (params: any) => {
+        return { data: { html_url: `https://github.com/mock/issue/${params.issue_number}`, ...params } };
+      },
+      createComment: async (params: any) => {
+        return { data: { html_url: `https://github.com/mock/issue/${params.issue_number}#comment`, ...params } };
       }
     }
   };
@@ -27,6 +37,7 @@ async function testGitHubClientAssignToJules() {
   client.octokit = new MockOctokit();
 
   const featureResult: GeminiAnalysisResult = {
+    action: "create",
     category: "[Feature]",
     title: "Clear Requirement",
     description: "Implement search feature.",
@@ -56,6 +67,7 @@ async function testGitHubClientAmbiguity() {
   client.octokit = new MockOctokit();
 
   const ambiguousResult: GeminiAnalysisResult = {
+    action: "create",
     category: "[Feature]",
     title: "Vague Requirement",
     description: "Do something nicely.",
@@ -84,9 +96,63 @@ async function testGitHubClientAmbiguity() {
   }
 }
 
+async function testGitHubClientUpdate() {
+  console.log("Running testGitHubClientUpdate...");
+
+  const client = new GitHubClient("fake-token", "owner/repo");
+  // @ts-ignore
+  client.octokit = new MockOctokit();
+
+  const updateResult: GeminiAnalysisResult = {
+    action: "update",
+    issue_number: 123,
+    category: "[Feature]",
+    title: "Updated Title",
+    description: "Updated description.",
+    acceptance_criteria: "Updated criteria.",
+    is_ambiguous: false,
+    missing_info: []
+  };
+
+  const issue = await client.updateIssue(123, updateResult);
+
+  console.log("Updated Issue URL:", issue.html_url);
+  console.log("Updated Issue Title:", issue.title);
+
+  if (issue.issue_number === 123 && issue.title.includes("Updated Title")) {
+    console.log("✅ Test Passed: Issue correctly updated.");
+  } else {
+    console.error("❌ Test Failed: Issue was not correctly updated.");
+    process.exit(1);
+  }
+}
+
+async function testGitHubClientComment() {
+  console.log("Running testGitHubClientComment...");
+
+  const client = new GitHubClient("fake-token", "owner/repo");
+  // @ts-ignore
+  client.octokit = new MockOctokit();
+
+  const commentBody = "This is a test comment.";
+  const comment = await client.addComment(123, commentBody);
+
+  console.log("Comment URL:", comment.html_url);
+  console.log("Comment Body:", comment.body);
+
+  if (comment.issue_number === 123 && comment.body === commentBody) {
+    console.log("✅ Test Passed: Comment correctly added.");
+  } else {
+    console.error("❌ Test Failed: Comment was not correctly added.");
+    process.exit(1);
+  }
+}
+
 async function runTests() {
   await testGitHubClientAssignToJules();
   await testGitHubClientAmbiguity();
+  await testGitHubClientUpdate();
+  await testGitHubClientComment();
 }
 
 runTests().catch(err => {

--- a/tests/test_slack_feedback.ts
+++ b/tests/test_slack_feedback.ts
@@ -7,6 +7,7 @@ const testCases = [
   {
     name: 'Clear Feature Request',
     result: {
+      action: 'create',
       category: '[Feature]',
       title: 'Add login',
       description: 'Add Google login',
@@ -23,6 +24,7 @@ const testCases = [
   {
     name: 'Ambiguous Clarify Request',
     result: {
+      action: 'create',
       category: '[Clarify]',
       title: 'Vague request',
       description: 'Something vague',
@@ -41,6 +43,7 @@ const testCases = [
   {
     name: 'Dependency Request',
     result: {
+      action: 'create',
       category: '[Dependency]',
       title: 'Need API Key',
       description: 'Need Stripe API key',
@@ -53,6 +56,38 @@ const testCases = [
       'Category: [Dependency]',
       '*Missing Information / Questions:*',
       '- Please provide the production API key'
+    ]
+  },
+  {
+    name: 'Update Request',
+    result: {
+      action: 'update',
+      category: '[Feature]',
+      title: 'Updated login',
+      description: 'Updated Google login',
+      acceptance_criteria: 'Given...',
+      is_ambiguous: false,
+      missing_info: []
+    } as GeminiAnalysisResult,
+    expectedContains: [
+      'GitHub Issue updated: https://github.com/owner/repo/issues/1',
+      'Category: [Feature]'
+    ]
+  },
+  {
+    name: 'Comment Request',
+    result: {
+      action: 'comment',
+      category: '[Feature]',
+      title: 'Add login',
+      description: 'Comment text',
+      acceptance_criteria: '',
+      is_ambiguous: false,
+      missing_info: []
+    } as GeminiAnalysisResult,
+    expectedContains: [
+      'GitHub Issue commented on: https://github.com/owner/repo/issues/1',
+      'Category: [Feature]'
     ]
   }
 ];


### PR DESCRIPTION
This change shifts the application logic from always creating a new GitHub issue to allowing the LLM to update existing issues (especially [Clarify] ones) or add comments. This is achieved by:
1. Updating the `GeminiAnalysisResult` type to include `action` and `issue_number`.
2. Modifying `GeminiEngine`'s system prompt to instruct it on when to use `update` or `comment` to avoid information fragmentation.
3. Adding `updateIssue` and `addComment` methods to `GitHubClient`.
4. Including issue `number` and `body` in the project context provided to Gemini.
5. Updating `handleSlackMessage` in `src/index.ts` to perform the action chosen by Gemini.
6. Updating the test suite to verify these new capabilities.

Fixes #60

---
*PR created automatically by Jules for task [6084052676837418852](https://jules.google.com/task/6084052676837418852) started by @studyhelperproject*