### PR TITLE
Implement GitHub Issue 'Read' Tool for Requirement Analysis

### DIFF
--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -1,5 +1,6 @@
-import { GoogleGenerativeAI, GenerativeModel } from "@google/generative-ai";
+import { GoogleGenerativeAI, GenerativeModel, SchemaType } from "@google/generative-ai";
 import { GeminiAnalysisResult } from "./types.js";
+import { GitHubClient } from "./github.js";
 
 export class GeminiEngine {
   private genAI: GoogleGenerativeAI;
@@ -33,6 +34,7 @@ Slackからの入力を分析し、以下のいずれかのアクションを選
 - [Feature] と判定するためには、その機能が「何を」「いつ」「どのように」するかが明確である必要があります（例：「Google OAuthを使用したログイン機能を追加し、ユーザー情報をDBに保存する」は [Feature]）。
 - [Feature] の場合、Acceptance Criteria（受入基準）を「Given/When/Then」形式で記述してください。
 - **重要**: 既存の [Clarify] Issueに関連する発言の場合、新規作成（create）せず、既存のIssueを更新（update）またはコメント（comment）してください。これにより情報の断片化を防ぎます。
+- **重要**: ユーザーが過去のIssue番号（例：Issue #3）やGitHubのIssue URLに言及し、その内容を知る必要がある場合は、必ず get_issue ツールを使用して内容を確認してください。
 
 ■出力フォーマット (JSON)
 {
@@ -54,10 +56,30 @@ Slackからの入力を分析し、以下のいずれかのアクションを選
 既存のIssueを更新（update）する場合は、元の内容（description等）を活かしつつ、最新の情報を反映させた「完成版」のIssue内容を提供してください。
 Slackのスレッド履歴が提供された場合、これまでの会話の流れを把握し、すでにユーザーから提供された情報を再度質問しないようにしてください。
 `,
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "get_issue",
+              description: "GitHub Issueの内容（タイトルと本文）を取得します。",
+              parameters: {
+                type: SchemaType.OBJECT,
+                properties: {
+                  issue_number: {
+                    type: SchemaType.NUMBER,
+                    description: "取得するIssueの番号（例：3）",
+                  },
+                },
+                required: ["issue_number"],
+              },
+            },
+          ],
+        },
+      ],
     });
   }
 
-  async analyzeMessage(message: string, context?: string, threadHistory?: string): Promise<GeminiAnalysisResult> {
+  async analyzeMessage(message: string, context?: string, threadHistory?: string, githubClient?: GitHubClient): Promise<GeminiAnalysisResult> {
     let prompt = "";
     if (context) {
       prompt += `以下のプロジェクト状況（YAML形式）を考慮して、ユーザーの入力を分析してください。\n\n[Project Context]\n${context}\n\n`;
@@ -67,19 +89,40 @@ Slackのスレッド履歴が提供された場合、これまでの会話の流
     }
     prompt += `[User Input]\n${message}`;
 
-    const result = await this.model.generateContent({
-      contents: [
-        { role: "user", parts: [{ text: prompt }] }
-      ],
-      generationConfig: {
-        responseMimeType: "application/json",
-      },
-    });
+    const chat = this.model.startChat();
+    let result = await chat.sendMessage(prompt);
+    let response = result.response;
 
-    const response = await result.response;
+    // Handle function calls loop
+    while (response.functionCalls() && response.functionCalls()!.length > 0) {
+      const toolResults: any[] = [];
+      for (const call of response.functionCalls()!) {
+        if (call.name === "get_issue" && githubClient) {
+          const { issue_number } = call.args as { issue_number: number };
+          console.log(`- Calling get_issue tool for Issue #${issue_number}`);
+          const issueContent = await githubClient.getIssue(issue_number);
+          toolResults.push({
+            functionResponse: {
+              name: "get_issue",
+              response: { content: issueContent },
+            },
+          });
+        }
+      }
+
+      if (toolResults.length > 0) {
+        result = await chat.sendMessage(toolResults);
+        response = result.response;
+      } else {
+        break;
+      }
+    }
+
     const text = response.text();
     try {
-      return JSON.parse(text) as GeminiAnalysisResult;
+      // Remove possible markdown block formatting
+      const cleanedText = text.replace(/^```json\n?/, "").replace(/\n?```$/, "");
+      return JSON.parse(cleanedText) as GeminiAnalysisResult;
     } catch (e) {
       console.error("Failed to parse Gemini response:", text);
       throw e;

--- a/src/github.ts
+++ b/src/github.ts
@@ -192,6 +192,21 @@ export class GitHubClient {
     }
   }
 
+  async getIssue(issueNumber: number): Promise<string> {
+    try {
+      const response = await this.octokit.rest.issues.get({
+        owner: this.owner,
+        repo: this.repo,
+        issue_number: issueNumber,
+      });
+      const issue = response.data;
+      return `Issue #${issue.number}: ${issue.title}\n\n${issue.body || ""}`;
+    } catch (error) {
+      console.error(`Failed to fetch GitHub issue #${issueNumber}:`, error);
+      return `Error: Could not fetch issue #${issueNumber}.`;
+    }
+  }
+
   async getProjectContext(): Promise<string> {
     try {
       const issues = await this.octokit.paginate(this.octokit.rest.issues.listForRepo, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ async function handleSlackMessage({ text, ts, thread_ts, channel, client, logger
     const context = await channelGitHubClient.getProjectContext();
 
     // Analyze message with Gemini
-    const result = await geminiEngine.analyzeMessage(text, context, threadHistory);
+    const result = await geminiEngine.analyzeMessage(text, context, threadHistory, channelGitHubClient);
     console.log("Gemini Analysis:", JSON.stringify(result, null, 2));
 
     // Perform action on GitHub issue

--- a/src/verify_github.ts
+++ b/src/verify_github.ts
@@ -18,6 +18,7 @@ async function verify() {
 
   const testCases: GeminiAnalysisResult[] = [
     {
+      action: "create",
       category: "[Feature]",
       title: "Google連携ボタンの追加",
       description: "ログイン画面にGoogle連携ボタンを追加し、認証を可能にする。",
@@ -26,6 +27,7 @@ async function verify() {
       missing_info: []
     },
     {
+      action: "create",
       category: "[Clarify]",
       title: "デザインの改善",
       description: "デザインを『いい感じ』にする。",
@@ -50,6 +52,7 @@ async function verify() {
 function mockVerify() {
   const testCases: GeminiAnalysisResult[] = [
     {
+      action: "create",
       category: "[Feature]",
       title: "Google連携ボタンの追加",
       description: "ログイン画面にGoogle連携ボタンを追加し、認証を可能にする。",
@@ -58,6 +61,7 @@ function mockVerify() {
       missing_info: []
     },
     {
+      action: "create",
       category: "[Clarify]",
       title: "デザインの改善",
       description: "デザインを『いい感じ』にする。",

--- a/tests/simple.ts
+++ b/tests/simple.ts
@@ -1,0 +1,1 @@
+console.log('hello')

--- a/tests/test_gemini_mock.ts
+++ b/tests/test_gemini_mock.ts
@@ -13,21 +13,24 @@ async function testGeminiMock() {
   // Manually override the model property to inject mock behavior
   // This is a simplified mock for the sake of the test environment
   (engine as any).model = {
-    generateContent: async (params: any) => {
-      console.log(`- Mocking generateContent call for model: ${(engine as any).model.modelName || 'gemini-3-flash-preview'}`);
-      return {
-        response: {
-          text: () => JSON.stringify({
-            category: "[Feature]",
-            title: "Mocked Task",
-            description: "A task analyzed by the mock engine.",
-            acceptance_criteria: "Given... When... Then...",
-            is_ambiguous: false,
-            missing_info: []
-          })
-        }
-      };
-    },
+    startChat: () => ({
+      sendMessage: async (prompt: string) => {
+        console.log(`- Mocking sendMessage call for model: ${(engine as any).model.modelName || 'gemini-3-flash-preview'}`);
+        return {
+          response: {
+            functionCalls: () => [],
+            text: () => JSON.stringify({
+              category: "[Feature]",
+              title: "Mocked Task",
+              description: "A task analyzed by the mock engine.",
+              acceptance_criteria: "Given... When... Then...",
+              is_ambiguous: false,
+              missing_info: []
+            })
+          }
+        };
+      }
+    }),
     modelName: "gemini-3-flash-preview"
   };
 

--- a/tests/test_read_tool.ts
+++ b/tests/test_read_tool.ts
@@ -1,0 +1,75 @@
+import { GeminiEngine } from "../src/gemini.js";
+import { GitHubClient } from "../src/github.js";
+
+async function testReadTool() {
+  console.log("Running test for GeminiEngine Read Tool (get_issue)...");
+
+  const apiKey = "dummy-key";
+  const engine = new GeminiEngine(apiKey);
+
+  // Mock GitHubClient
+  const mockGitHubClient = {
+    getIssue: async (issueNumber: number) => {
+      console.log(`- Mock GitHubClient.getIssue called for #${issueNumber}`);
+      return `Issue #${issueNumber}: Original Requirement\n\nThis is the content of issue #${issueNumber}.`;
+    }
+  } as any as GitHubClient;
+
+  // Mock Gemini model and chat
+  (engine as any).model = {
+    startChat: () => {
+      let callCount = 0;
+      return {
+        sendMessage: async (prompt: any) => {
+          callCount++;
+          if (callCount === 1) {
+            // First call: Gemini returns a function call
+            return {
+              response: {
+                functionCalls: () => [{
+                  name: "get_issue",
+                  args: { issue_number: 3 }
+                }],
+                text: () => ""
+              }
+            };
+          } else {
+            // Second call: Gemini returns the final JSON analysis
+            return {
+              response: {
+                functionCalls: () => [],
+                text: () => JSON.stringify({
+                  action: "update",
+                  issue_number: 3,
+                  category: "[Feature]",
+                  title: "Updated Task based on Issue #3",
+                  description: "This task was updated using information from Issue #3.",
+                  acceptance_criteria: "Given... When... Then...",
+                  is_ambiguous: false,
+                  missing_info: []
+                })
+              }
+            };
+          }
+        }
+      };
+    }
+  };
+
+  try {
+    const result = await engine.analyzeMessage("Issue #3の内容を元に進めて", undefined, undefined, mockGitHubClient);
+    console.log("Analysis Result:", JSON.stringify(result, null, 2));
+
+    if (result.action === "update" && result.issue_number === 3) {
+      console.log("✅ Read Tool Test Passed: Gemini correctly called get_issue and used the result.");
+    } else {
+      console.error("❌ Read Tool Test Failed: Unexpected result.");
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error("❌ Read Tool Test Failed with error:", error);
+    process.exit(1);
+  }
+}
+
+testReadTool();

--- a/tests/test_thread_history.ts
+++ b/tests/test_thread_history.ts
@@ -10,21 +10,24 @@ async function testThreadHistoryIntegration() {
 
   // Mocking the model to capture the constructed prompt
   (engine as any).model = {
-    generateContent: async (params: any) => {
-      capturedPrompt = params.contents[0].parts[0].text;
-      return {
-        response: {
-          text: () => JSON.stringify({
-            category: "[Feature]",
-            title: "Mocked Task",
-            description: "A task analyzed with thread history.",
-            acceptance_criteria: "Given... When... Then...",
-            is_ambiguous: false,
-            missing_info: []
-          })
-        }
-      };
-    },
+    startChat: () => ({
+      sendMessage: async (prompt: string) => {
+        capturedPrompt = prompt;
+        return {
+          response: {
+            functionCalls: () => [],
+            text: () => JSON.stringify({
+              category: "[Feature]",
+              title: "Mocked Task",
+              description: "A task analyzed with thread history.",
+              acceptance_criteria: "Given... When... Then...",
+              is_ambiguous: false,
+              missing_info: []
+            })
+          }
+        };
+      }
+    }),
     modelName: "gemini-3-flash-preview"
   };
 


### PR DESCRIPTION
This change implements a "Read tool" for GitHub issues, allowing the bot to fetch and understand existing issues when referenced by number (e.g., "Issue #3") or URL in a Slack conversation.

Key changes:
1. **GitHub Integration**: Added `GitHubClient.getIssue()` to retrieve an issue's content via the API.
2. **LLM Tool Calling**: Modified `GeminiEngine` to define the `get_issue` tool and implemented a loop in `analyzeMessage` to handle function calls. Gemini now automatically fetches issue details when it needs context about a mentioned issue.
3. **Glue Code**: Updated the main message handler in `index.ts` to provide the channel-specific GitHub client to the analysis engine.
4. **Maintenance**: Fixed type errors in verification scripts and updated existing mock tests to support the new `startChat`-based execution flow. Removed compiled `.js` files from the `src/` directory to maintain a pure TypeScript environment.

Fixes #62

---
*PR created automatically by Jules for task [9958099135540615183](https://jules.google.com/task/9958099135540615183) started by @studyhelperproject*